### PR TITLE
Job to Remove Validation Reports for Unsupported Resource Types

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,14 @@ To prevent the extension from adding the validation badges next to the resources
 
     ckanext.validation.show_badges_in_listings = False
 
+### Clean validation reports
+
+To prevent the extension from keeping validation reports for unsupported Resource formats. Defaults to False:
+
+    ckanext.validation.clean_validation_reports = True
+
+Once a Resource is updated and its format is not supported in ckanext.validation.formats, a job will be enqueued to remove the validation reports from the Resource.
+
 
 ## How it works
 

--- a/ckanext/validation/logic.py
+++ b/ckanext/validation/logic.py
@@ -217,12 +217,16 @@ def resource_validation_delete(context, data_dict):
         context, {u'id': data_dict[u'resource_id']})
 
     try:
-        resource.pop(u'validation_status')
-        resource.pop(u'validation_options')
-        resource.pop(u'validation_timestamp')
+        if resource.get('validation_status', False):
+            resource.pop(u'validation_status')
+        if resource.get('validation_options', False):
+            resource.pop(u'validation_options')
+        if resource.get('validation_timestamp', False):
+            resource.pop(u'validation_timestamp')
+        user = t.get_action('get_site_user')({'ignore_auth': True})
         t.get_action('resource_update')(
             {'ignore_auth': True,
-             'user': t.get_action('get_site_user')({'ignore_auth': True})['name']},
+             'user': user.get('name', 'ckan-system')},
             resource)
     except KeyError:
         log.error('Unable to remove validation metadata from resource ' + resource['id'])

--- a/ckanext/validation/plugin.py
+++ b/ckanext/validation/plugin.py
@@ -337,7 +337,7 @@ def _should_remove_unsupported_resource_validation_reports(res_dict):
 def _remove_unsupported_resource_validation_reports(resource_id):
     """
     Callback to remove unsupported validation reports.
-    Controlled by config value: ckanext.validation.limit_validation_reports.
+    Controlled by config value: ckanext.validation.clean_validation_reports.
     Double check the resource format. Only supported Validation formats should have validation reports.
     If the resource format is not supported, we should delete the validation reports.
     """
@@ -349,7 +349,7 @@ def _remove_unsupported_resource_validation_reports(resource_id):
         log.error('Resource %s does not exist.' % res['id'])
         return
 
-    # only remove validation reports from dataset types
+    # only remove validation reports from dataset types (canada fork only)
     if pkg['type'] != 'dataset':
         return
 

--- a/ckanext/validation/plugin.py
+++ b/ckanext/validation/plugin.py
@@ -324,7 +324,7 @@ def _run_async_validation(resource_id):
 
 
 def _should_remove_unsupported_resource_validation_reports(res_dict):
-    if not t.h.asbool(t.config.get('ckanext.validation.limit_validation_reports', False)):
+    if not t.h.asbool(t.config.get('ckanext.validation.clean_validation_reports', False)):
         return False
     return ((not res_dict.get('format', u'').lower() in settings.SUPPORTED_FORMATS
                 or res_dict.get('url_changed', False))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 ckantoolkit>=0.0.3
 goodtables==1.5.1
 -e git+https://github.com/ckan/ckanext-scheming.git#egg=ckanext-scheming
+ckanapi


### PR DESCRIPTION
feat(dev): implemented IDomainObjectModification;

- Implemented `IDomainObjectModification`.
- Queued new job callback for unsupported validation resources.
- Added new config option `ckanext.validation.limit_validation_reports`.

See https://github.com/open-data/ckanext-canada/pull/1382 for more discussion.