### PR TITLE
Prevent Xloader/Validation Loop

### DIFF
--- a/ckanext/validation/plugin/__init__.py
+++ b/ckanext/validation/plugin/__init__.py
@@ -252,6 +252,13 @@ class ValidationPlugin(MixinPlugin, p.SingletonPlugin, DefaultTranslation):
             del context['_validation_performed']
             return
 
+        if context.get('_canada_is_doing_xloader'):
+            # (canada fork only): prevent re-validating from updates
+            # and patches from the ckanext-xloader plugin.
+            log.debug('Skipping validation for resource %s because Xloader is just patching...', data_dict['id'])
+            del context['_canada_is_doing_xloader']
+            return
+
         if is_dataset:
             for resource in data_dict.get(u'resources', []):
                 if resource[u'id'] in self.resources_to_validate:


### PR DESCRIPTION
fix(dev): do not validate if xloader;

- Uses custom Context key value from Xloader to not validate if Xloader is calling `resource_update` or `resource_patch`.

@wardi I never noticed this locally as I do my local jobs in burst mode in most of my environments. But I noticed it on our site with larger Resources this morning. So what happens is Xloader will call `resource_patch` and then ckanext-validation will happen again and queue another job for that Resource. It will do the Validation job AGAIN, and then it will submit it to Xloader AGAIN, and then Xloader will stop because the file hashes are the same. Very bad!